### PR TITLE
Rooms: order based at users count

### DIFF
--- a/src/components/Room.svelte
+++ b/src/components/Room.svelte
@@ -83,9 +83,14 @@
   }
 </style>
 
-{#if !globalyPinnedRoom}
+{#if globalyPinnedRoom}
   <i
     class="nes-icon is-small star"
+    alt="globally_pinned_room"
+  />
+{:else}
+  <i
+    class="nes-icon is-small heart"
     class:is-empty={!pinnedRoom}
     on:click={togglePin}
   />

--- a/src/containers/Rooms.svelte
+++ b/src/containers/Rooms.svelte
@@ -10,7 +10,7 @@
 	export let activeRoomName
 	export let pinnedRooms
 	export let filters = {
-		name: ''
+		name: '',
 	}
 
 	const filterRooms = (rooms, filters) => rooms
@@ -33,7 +33,12 @@
 			.filter(({ id, globalyPinnedRoom }) => pinnedRooms[id] && !globalyPinnedRoom)
 
 		const notPinnedRooms = allRooms
-			.filter(({ id, globalyPinnedRoom }) => !pinnedRooms[id] && !globalyPinnedRoom)
+      .filter(({ id, globalyPinnedRoom }) => !pinnedRooms[id] && !globalyPinnedRoom)
+      .sort((base, compared) => {
+        const baseUsersCount = Object.keys(base.users || {}).length
+        const comparedUsersCount = Object.keys(compared.users || {}).length
+        return comparedUsersCount - baseUsersCount
+      })
 
 		filteredRooms = filterRooms([
 			...globalyPinnedRooms,


### PR DESCRIPTION
## Description

This PR adds a new order for the rooms system, now also using the users count as a sorting mechanism.

This PR also enhance a bit the look'n feel of the rooms labels, showing starts at globally pinned rooms and hearts for manually pinned rooms.

<img width="406" alt="Screen Shot 2019-08-01 at 21 24 20" src="https://user-images.githubusercontent.com/8251208/62335604-be2f8e00-b4a2-11e9-87cf-87005aa97715.png">


Implements https://github.com/lucianopf/escritorio-pagarme/issues/38