### PR TITLE
Fix search re-enter rooms problem

### DIFF
--- a/src/components/Room.svelte
+++ b/src/components/Room.svelte
@@ -104,7 +104,7 @@
 
   const pathRoom = getCurrentPath()
 
-  if (pathRoom === slugify(name)) {
+  if (pathRoom === slugify(name) && !active) {
     enterRoom()
   }
 </script>


### PR DESCRIPTION
# Description

There was a problem when re-rendering the room, which the user was already active but either ways the user was trying to re-enter the room, causing some disruption at the video component.

