### PR TITLE
Security related to auto-join at Jitsi

### DIFF
--- a/src/components/Meet.svelte
+++ b/src/components/Meet.svelte
@@ -24,6 +24,10 @@
         width: "100%",
         height: "80%",
         parentNode: meetDiv,
+        configOverwrite: {
+          startWithAudioMuted: true,
+          startWithVideoMuted: true,
+        },
         interfaceConfigOverwrite: {
           TOOLBAR_BUTTONS: [
             'camera',


### PR DESCRIPTION
# Description

This PR aims to setup Jitsi to disable by default video and audio whenever you join a Room, and than you'll need to manually enable it to start chatting.

Reasons:
- If you leave your computer somewhere with an open tab when you login in a different computer and join a different room, by default it will open the meeting where you're at and where you left your PC logged in, which can be an issue security wise, since there's no actually permission for this user to be sharing the video or audio.

- For some reason you're at home and theres an exploit that a hacker can move you inside rooms, this will automatically provide the hacker with your video/audio, which can be very harmful.


There are a couple other small issues, but those are the top priority in my mind.

This problem has been reported by https://github.com/darakeon and it makes totally sense!