### PR TITLE
Join without audio issue

### DIFF
--- a/src/components/Meet.svelte
+++ b/src/components/Meet.svelte
@@ -25,7 +25,6 @@
         height: "80%",
         parentNode: meetDiv,
         configOverwrite: {
-          startWithAudioMuted: true,
           startWithVideoMuted: true,
         },
         interfaceConfigOverwrite: {


### PR DESCRIPTION
# Description

Unfortunately Jitsi options aren't as good as we thought and it doesn't always work as expected, and because of it leaving it enabled will sometimes cause audio output failures.

It's a sad movement but it is required to stop facing bugs =/ 😢
